### PR TITLE
OPM Configs for Moonlets and Captured Asteroids

### DIFF
--- a/config/OPM-Reconfig.cfg
+++ b/config/OPM-Reconfig.cfg
@@ -1,8 +1,12 @@
-// Original draft 2019/02/20 by Eridan/HSJasperism
+// Updated 2019/03/18 by Eridan/HSJasperism
+// Tested with OPM 2.2.2 & CA 1.6
+// OPM older than 2.2.2 of OPM will include dated configs for CA or Kopernicus Asteroids
+// CA older than 1.3 will fail to recognize spawn conditions
 
 // Removes the Asteroid configs for Kopernicus
 // Kopernicus will still load its ScenarioModule named DiscoverableObjects after killing stock ScenarioDiscoverableObjects
-// but void Start()'s foreach loop will not go though anything because no Asteroid configs will exist.
+// but Start()'s foreach loop will not go though anything because no Asteroid configs will exist.
+// CA has defaults for Dres & Kerbin in PopulationLoader.cs but it is recommended to use the stockalike CA configs
 
 @Kopernicus:AFTER[OPM]:NEEDS[CustomAsteroids]
 {
@@ -14,9 +18,9 @@
 
 // Custom Asteroid Configs
 // Jool, Sarnus, Urlum, & Neidon configs based on Artifexian's tutorials on Gas Giant systems
-// Sarnus, Urlum, & Neidon attempt to mimic JadOfMaar's configs
+// Sarnus, Urlum, & Neidon attempt to mimic JadOfMaar's Kopernicus configs
 
-AsteroidSets:NEEDS[CustomAsteroids]
+AsteroidSets:NEEDS[OPM]
 {
 	name = OPM_GasGiantObjects
 
@@ -48,27 +52,6 @@ AsteroidSets:NEEDS[CustomAsteroids]
 			dist = Rayleigh
 			avg = 0
 			stddev = 0.05
-		}
-
- 		ascNode
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		periapsis
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		orbitPhase
-		{
-			dist = Uniform
-			min = 0
-			max = 360
 		}
 
  		asteroidTypes
@@ -109,27 +92,6 @@ AsteroidSets:NEEDS[CustomAsteroids]
 			stddev = 0.05
 		}
 
- 		ascNode
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		periapsis
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		orbitPhase
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
  		asteroidTypes
 		{
 			key = 0.75 PotatoRoid
@@ -166,27 +128,6 @@ AsteroidSets:NEEDS[CustomAsteroids]
 			dist = Rayleigh
 			avg = 0
 			stddev = 0.05
-		}
-
- 		ascNode
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		periapsis
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		orbitPhase
-		{
-			dist = Uniform
-			min = 0
-			max = 360
 		}
 
  		asteroidTypes
@@ -233,20 +174,6 @@ AsteroidSets:NEEDS[CustomAsteroids]
 			stddev = 0.5
 		}
 
- 		periapsis
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		orbitPhase
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
  		asteroidTypes
 		{
 			key = 0.10 CaAsteroidCarbon
@@ -279,30 +206,7 @@ AsteroidSets:NEEDS[CustomAsteroids]
 
  		inclination
 		{
-			dist = Uniform
-			min = 0
-			max = 180
-		}
-
- 		ascNode
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		periapsis
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		orbitPhase
-		{
-			dist = Uniform
-			min = 0
-			max = 360
+			dist = Isotropic
 		}
 
  		asteroidTypes
@@ -338,30 +242,7 @@ AsteroidSets:NEEDS[CustomAsteroids]
 
  		inclination
 		{
-			dist = Uniform
-			min = 0
-			max = 180
-		}
-
- 		ascNode
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		periapsis
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		orbitPhase
-		{
-			dist = Uniform
-			min = 0
-			max = 360
+			dist = Isotropic
 		}
 
  		asteroidTypes
@@ -397,30 +278,7 @@ AsteroidSets:NEEDS[CustomAsteroids]
 
  		inclination
 		{
-			dist = Uniform
-			min = 0
-			max = 180
-		}
-
- 		ascNode
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		periapsis
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		orbitPhase
-		{
-			dist = Uniform
-			min = 0
-			max = 360
+			dist = Isotropic
 		}
 
  		asteroidTypes
@@ -455,30 +313,7 @@ AsteroidSets:NEEDS[CustomAsteroids]
 
  		inclination
 		{
-			dist = Uniform
-			min = 0
-			max = 180
-		}
-
- 		ascNode
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		periapsis
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-
- 		orbitPhase
-		{
-			dist = Uniform
-			min = 0
-			max = 360
+			dist = Isotropic
 		}
 		
  		asteroidTypes
@@ -489,11 +324,61 @@ AsteroidSets:NEEDS[CustomAsteroids]
 	}
 }
 
+@AsteroidSets[OPM_GasGiantObjects]:NEEDS[!UnhideAsteroids]
+{
+	@ASTEROIDGROUP:HAS[#centralBody[Jool]]
+	{
+		detectable
+		{
+			conditions
+			{
+				condition = Jool.reached
+			}
+		}
+	}
+	
+	@ASTEROIDGROUP:HAS[#centralBody[Sarnus]]
+	{
+		detectable
+		{
+			conditions
+			{
+				condition = Sarnus.reached
+			}
+		}
+	}
+	
+	@ASTEROIDGROUP:HAS[#centralBody[Urlum]]
+	{
+		detectable
+		{
+			conditions
+			{
+				condition = Urlum.reached
+			}
+		}
+	}
+	
+	@ASTEROIDGROUP:HAS[#centralBody[Neidon]]
+	{
+		detectable
+		{
+			conditions
+			{
+				condition = Neidon.reached
+			}
+		}
+	}
+}
+
 Localization
 {
 	en-us
 	{
-    #autoLOC_CustomAsteroids_OPM_GroupInnerObj = Gas Giant Moonlet
-    #autoLOC_CustomAsteroids_OPM_GroupOuterObj = Captured Asteroid
+		// Minor satellites
+    	#autoLOC_CustomAsteroids_OPM_GroupInnerObj = Minor Sat.
+		// Captured Objects
+    	#autoLOC_CustomAsteroids_OPM_GroupOuterObj = Captured Ast.
 	}
 }
+

--- a/config/OPM-Reconfig.cfg
+++ b/config/OPM-Reconfig.cfg
@@ -1,10 +1,10 @@
 // Original draft 2019/02/20 by Eridan/HSJasperism
 
- // Removes the Asteroid configs for Kopernicus
+// Removes the Asteroid configs for Kopernicus
 // Kopernicus will still load its ScenarioModule named DiscoverableObjects after killing stock ScenarioDiscoverableObjects
 // but void Start()'s foreach loop will not go though anything because no Asteroid configs will exist.
 
- @Kopernicus:AFTER[OPM]:NEEDS[CustomAsteroids]
+@Kopernicus:AFTER[OPM]:NEEDS[CustomAsteroids]
 {
 	!Asteroid[Stock] {}
 	!Asteroid[OPMSarnus] {}
@@ -12,11 +12,11 @@
 	!Asteroid[OPMNeidon] {}
 }
 
- // Custom Asteroid Configs
+// Custom Asteroid Configs
 // Jool, Sarnus, Urlum, & Neidon configs based on Artifexian's tutorials on Gas Giant systems
 // Sarnus, Urlum, & Neidon attempt to mimic JadOfMaar's configs
 
-AsteroidSets:AFTER[OPM]:NEEDS[CustomAsteroids]
+AsteroidSets:NEEDS[CustomAsteroids]
 {
 	name = OPM_GasGiantObjects
 
@@ -92,7 +92,7 @@ AsteroidSets:AFTER[OPM]:NEEDS[CustomAsteroids]
 		{
 			dist = Uniform
 			min = Ratio(Sarnus.rad, 1.89)
-			max = Ratio(Sarnus.rad, 2.44)
+			max = Ratio(Ovok.sma, 1)
 		}
 
  		eccentricity
@@ -149,9 +149,9 @@ AsteroidSets:AFTER[OPM]:NEEDS[CustomAsteroids]
 
  		orbitSize
 		{
-			dist = Gaussian
-			avg = Ratio(Priax.sma, 1)
-			stddev = 0.05
+			dist = Uniform
+			min = Ratio(Urlum.rad, 1.89)
+			max = Ratio(Priax.sma, 1)
 		}
 
  		eccentricity
@@ -170,23 +170,23 @@ AsteroidSets:AFTER[OPM]:NEEDS[CustomAsteroids]
 
  		ascNode
 		{
-			dist = Gaussian
-			avg = Ratio(Priax.lan, 1)
-			stddev = 0.05
+			dist = Uniform
+			min = 0
+			max = 360
 		}
 
  		periapsis
 		{
 			dist = Uniform
-			min = 120
+			min = 0
 			max = 360
 		}
 
  		orbitPhase
 		{
-			dist = Gaussian
-			avg = Ratio(Priax.mna, 1)
-			stddev = 0.05
+			dist = Uniform
+			min = 0
+			max = 360
 		}
 
  		asteroidTypes
@@ -209,7 +209,7 @@ AsteroidSets:AFTER[OPM]:NEEDS[CustomAsteroids]
 		{
 			dist = Uniform
 			min = Ratio(Neidon.rad, 1.89)
-			max = Ratio(Neidon.rad, 2.44)
+			max = Ratio(Thatmo.sma, 1)
 		}
 
  		eccentricity
@@ -229,7 +229,7 @@ AsteroidSets:AFTER[OPM]:NEEDS[CustomAsteroids]
  		ascNode
 		{
 			dist = Gaussian
-			avg = Ratio(Thatmo.asc, 1)
+			avg = Ratio(Thatmo.lan, 1)
 			stddev = 0.5
 		}
 
@@ -325,8 +325,8 @@ AsteroidSets:AFTER[OPM]:NEEDS[CustomAsteroids]
  		orbitSize
 		{
 			dist = Uniform
-			min = Ratio(Slate.rad, 2)
-			max = Ratio(Tekto.rad, 1)
+			min = Ratio(Slate.sma, 2)
+			max = Ratio(Tekto.sma, 2)
 		}
 
  		eccentricity
@@ -385,7 +385,7 @@ AsteroidSets:AFTER[OPM]:NEEDS[CustomAsteroids]
 		{
 			dist = Uniform
 			min = Ratio(Priax.sma, 2)
-			max = Ratio(Wal.sma, 1)
+			max = Ratio(Wal.sma, 2)
 		}
 
  		eccentricity

--- a/config/OPM-Reconfig.cfg
+++ b/config/OPM-Reconfig.cfg
@@ -1,0 +1,266 @@
+// Original draft 2019/02/20 by Eridan/HSJasperism
+
+// Removes the Asteroid configs for Kopernicus
+// Kopernicus will still load its ScenarioModule named DiscoverableObjects after killing stock ScenarioDiscoverableObjects
+// but void Start()'s foreach loop will not go though anything because no Asteroid configs will exist.
+
+@Kopernicus:AFTER[OPM]:NEEDS[CustomAsteroids]
+{
+	!Asteroid[Stock] {}
+	!Asteroid[OPMSarnus] {}
+	!Asteroid[OPMUrlum] {}
+	!Asteroid[OPMNeidon] {}
+}
+
+// Custom Asteroid Configs
+// Jool, Sarnus, Urlum, & Neidon configs based on Artifexian's tutorials on Gas Giant systems
+// Sarnus, Urlum, & Neidon attempt to mimic JadOfMaar's configs
+
+AsteroidSets
+{
+	name = OPM_captured
+
+	ASTEROIDGROUP
+	{
+		name = joolInner
+		title = #autoLOC_CustomAsteroids_OPM_GroupInnerObj
+
+		centralBody = Jool
+
+		spawnRate = 0.09
+
+		orbitSize
+		{
+			dist = Uniform
+			min = Ratio(Jool.rad, 1.89)
+			max = Ratio(Jool.rad, 2.44)
+		}
+
+		eccentricity
+		{
+			dist = Rayleigh
+			avg = 0
+			stddev = 0.05
+		}
+
+		inclination
+		{
+			dist = Rayleigh
+			avg = 0
+			stddev = 0.05
+		}
+		
+		ascNode
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+		
+		periapsis
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+		
+		orbitPhase
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+		asteroidTypes
+		{
+			key = 0.75 PotatoRoid
+			key = 0.20 CaAsteroidCarbon
+			key = 0.05 CaAsteroidMetal
+		}
+	}
+
+	ASTEROIDGROUP
+	{
+		name = sarnusInner
+		title = #autoLOC_CustomAsteroids_OPM_GroupInnerObj
+
+		centralBody = Sarnus
+
+		spawnRate = 0.09
+
+		orbitSize
+		{
+			dist = Uniform
+			min = 17225000
+			max = 22909250
+		}
+
+		eccentricity
+		{
+			dist = Uniform
+			min = 0
+			max = 0.15
+		}
+
+		inclination
+		{
+			dist = Rayleigh
+			avg = 0
+			stddev = 0.05
+		}
+		
+		ascNode
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+		
+		periapsis
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+		
+		orbitPhase
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+		asteroidTypes
+		{
+			key = 0.75 PotatoRoid
+			key = 0.20 CaAsteroidCarbon
+			key = 0.05 CaAsteroidMetal
+		}
+	}
+
+	ASTEROIDGROUP
+	{
+		name = urlumInner
+		title = #autoLOC_CustomAsteroids_OPM_GroupInnerObj
+
+		centralBody = Urlum
+
+		spawnRate = 0.09
+
+		orbitSize
+		{
+			dist = Gaussian
+			avg = Ratio(Priax.sma, 1)
+			stddev = 0.05
+		}
+
+		eccentricity
+		{
+			dist = Rayleigh
+			avg = 0
+			stddev = 0.05
+		}
+
+		inclination
+		{
+			dist = Rayleigh
+			avg = 0
+			stddev = 0.05
+		}
+		
+		ascNode
+		{
+			dist = Gaussian
+			avg = Ratio(Priax.asc, 1)
+			stddev = 0.05
+		}
+		
+		periapsis
+		{
+			dist = Uniform
+			min = 120
+			max = 360
+		}
+		
+		orbitPhase
+		{
+			dist = Gaussian
+			avg = Ratio(Priax.mna, 1)
+			stddev = 0.05
+		}
+
+		asteroidTypes
+		{
+			key = 0.10 CaAsteroidCarbon
+			key = 0.90 CaAsteroidIcy
+		}
+	}
+
+	ASTEROIDGROUP
+	{
+		name = neidonCaptured
+		title = #autoLOC_CustomAsteroids_OPM_GroupOuterObj
+
+		centralBody = Neidon
+
+		spawnRate = 0.09
+
+		orbitSize
+		{
+			type = periapsis
+			dist = Uniform
+			min = Ratio(Neidon.rad, 1.89)
+			max = Ratio(Neidon.rad, 2.44)
+		}
+
+		eccentricity
+		{
+			dist = Uniform
+			min = 0
+			max = 0.4
+		}
+
+		inclination
+		{
+			dist = Gaussian
+			avg = Ratio(Thatmo.inc, 1)
+			stddev = 0.5
+		}
+		
+		ascNode
+		{
+			dist = Gaussian
+			avg = Ratio(Thatmo.asc, 1)
+			stddev = 0.5
+		}
+		
+		periapsis
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+		
+		orbitPhase
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+		asteroidTypes
+		{
+			key = 0.10 CaAsteroidCarbon
+			key = 0.90 CaAsteroidIcy
+		}
+	}
+}
+  
+Localization
+{
+	en-us
+	{
+    #autoLOC_CustomAsteroids_OPM_GroupInnerObj = Gas Giant Moonlet
+    #autoLOC_CustomAsteroids_OPM_GroupOuterObj = Captured Asteroid
+	}
+}

--- a/config/OPM-Reconfig.cfg
+++ b/config/OPM-Reconfig.cfg
@@ -1,10 +1,10 @@
 // Original draft 2019/02/20 by Eridan/HSJasperism
 
-// Removes the Asteroid configs for Kopernicus
+ // Removes the Asteroid configs for Kopernicus
 // Kopernicus will still load its ScenarioModule named DiscoverableObjects after killing stock ScenarioDiscoverableObjects
 // but void Start()'s foreach loop will not go though anything because no Asteroid configs will exist.
 
-@Kopernicus:AFTER[OPM]:NEEDS[CustomAsteroids]
+ @Kopernicus:AFTER[OPM]:NEEDS[CustomAsteroids]
 {
 	!Asteroid[Stock] {}
 	!Asteroid[OPMSarnus] {}
@@ -12,66 +12,66 @@
 	!Asteroid[OPMNeidon] {}
 }
 
-// Custom Asteroid Configs
+ // Custom Asteroid Configs
 // Jool, Sarnus, Urlum, & Neidon configs based on Artifexian's tutorials on Gas Giant systems
 // Sarnus, Urlum, & Neidon attempt to mimic JadOfMaar's configs
 
-AsteroidSets
+AsteroidSets:AFTER[OPM]:NEEDS[CustomAsteroids]
 {
-	name = OPM_captured
+	name = OPM_GasGiantObjects
 
-	ASTEROIDGROUP
+ 	ASTEROIDGROUP
 	{
 		name = joolInner
 		title = #autoLOC_CustomAsteroids_OPM_GroupInnerObj
 
-		centralBody = Jool
+ 		centralBody = Jool
 
-		spawnRate = 0.09
+ 		spawnRate = 0.15
 
-		orbitSize
+ 		orbitSize
 		{
 			dist = Uniform
 			min = Ratio(Jool.rad, 1.89)
 			max = Ratio(Jool.rad, 2.44)
 		}
 
-		eccentricity
+ 		eccentricity
 		{
 			dist = Rayleigh
 			avg = 0
 			stddev = 0.05
 		}
 
-		inclination
+ 		inclination
 		{
 			dist = Rayleigh
 			avg = 0
 			stddev = 0.05
 		}
-		
-		ascNode
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-		
-		periapsis
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-		
-		orbitPhase
+
+ 		ascNode
 		{
 			dist = Uniform
 			min = 0
 			max = 360
 		}
 
-		asteroidTypes
+ 		periapsis
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		orbitPhase
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		asteroidTypes
 		{
 			key = 0.75 PotatoRoid
 			key = 0.20 CaAsteroidCarbon
@@ -79,58 +79,58 @@ AsteroidSets
 		}
 	}
 
-	ASTEROIDGROUP
+ 	ASTEROIDGROUP
 	{
 		name = sarnusInner
 		title = #autoLOC_CustomAsteroids_OPM_GroupInnerObj
 
-		centralBody = Sarnus
+ 		centralBody = Sarnus
 
-		spawnRate = 0.09
+ 		spawnRate = 0.15
 
-		orbitSize
+ 		orbitSize
 		{
 			dist = Uniform
-			min = 17225000
-			max = 22909250
+			min = Ratio(Sarnus.rad, 1.89)
+			max = Ratio(Sarnus.rad, 2.44)
 		}
 
-		eccentricity
-		{
-			dist = Uniform
-			min = 0
-			max = 0.15
-		}
-
-		inclination
+ 		eccentricity
 		{
 			dist = Rayleigh
 			avg = 0
 			stddev = 0.05
 		}
-		
-		ascNode
+
+ 		inclination
 		{
-			dist = Uniform
-			min = 0
-			max = 360
+			dist = Rayleigh
+			avg = 0
+			stddev = 0.05
 		}
-		
-		periapsis
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-		
-		orbitPhase
+
+ 		ascNode
 		{
 			dist = Uniform
 			min = 0
 			max = 360
 		}
 
-		asteroidTypes
+ 		periapsis
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		orbitPhase
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		asteroidTypes
 		{
 			key = 0.75 PotatoRoid
 			key = 0.20 CaAsteroidCarbon
@@ -138,124 +138,357 @@ AsteroidSets
 		}
 	}
 
-	ASTEROIDGROUP
+ 	ASTEROIDGROUP
 	{
 		name = urlumInner
 		title = #autoLOC_CustomAsteroids_OPM_GroupInnerObj
 
-		centralBody = Urlum
+ 		centralBody = Urlum
 
-		spawnRate = 0.09
+ 		spawnRate = 0.15
 
-		orbitSize
+ 		orbitSize
 		{
 			dist = Gaussian
 			avg = Ratio(Priax.sma, 1)
 			stddev = 0.05
 		}
 
-		eccentricity
+ 		eccentricity
 		{
 			dist = Rayleigh
 			avg = 0
 			stddev = 0.05
 		}
 
-		inclination
+ 		inclination
 		{
 			dist = Rayleigh
 			avg = 0
 			stddev = 0.05
 		}
-		
-		ascNode
+
+ 		ascNode
 		{
 			dist = Gaussian
-			avg = Ratio(Priax.asc, 1)
+			avg = Ratio(Priax.lan, 1)
 			stddev = 0.05
 		}
-		
-		periapsis
+
+ 		periapsis
 		{
 			dist = Uniform
 			min = 120
 			max = 360
 		}
-		
-		orbitPhase
+
+ 		orbitPhase
 		{
 			dist = Gaussian
 			avg = Ratio(Priax.mna, 1)
 			stddev = 0.05
 		}
 
-		asteroidTypes
+ 		asteroidTypes
 		{
 			key = 0.10 CaAsteroidCarbon
 			key = 0.90 CaAsteroidIcy
 		}
 	}
 
-	ASTEROIDGROUP
+ 	ASTEROIDGROUP
 	{
-		name = neidonCaptured
-		title = #autoLOC_CustomAsteroids_OPM_GroupOuterObj
+		name = neidonInner
+		title = #autoLOC_CustomAsteroids_OPM_GroupInnerObj
 
-		centralBody = Neidon
+ 		centralBody = Neidon
 
-		spawnRate = 0.09
+ 		spawnRate = 0.15
 
-		orbitSize
+ 		orbitSize
 		{
-			type = periapsis
 			dist = Uniform
 			min = Ratio(Neidon.rad, 1.89)
 			max = Ratio(Neidon.rad, 2.44)
 		}
 
-		eccentricity
+ 		eccentricity
 		{
 			dist = Uniform
-			min = 0
+			min = 0.1
 			max = 0.4
 		}
 
-		inclination
+ 		inclination
 		{
 			dist = Gaussian
 			avg = Ratio(Thatmo.inc, 1)
 			stddev = 0.5
 		}
-		
-		ascNode
+
+ 		ascNode
 		{
 			dist = Gaussian
 			avg = Ratio(Thatmo.asc, 1)
 			stddev = 0.5
 		}
-		
-		periapsis
-		{
-			dist = Uniform
-			min = 0
-			max = 360
-		}
-		
-		orbitPhase
+
+ 		periapsis
 		{
 			dist = Uniform
 			min = 0
 			max = 360
 		}
 
-		asteroidTypes
+ 		orbitPhase
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		asteroidTypes
+		{
+			key = 0.10 CaAsteroidCarbon
+			key = 0.90 CaAsteroidIcy
+		}
+	}
+	
+ 	ASTEROIDGROUP
+	{
+		name = joolOuter
+		title = #autoLOC_CustomAsteroids_OPM_GroupOuterObj
+
+ 		centralBody = Jool
+
+ 		spawnRate = 0.10
+
+ 		orbitSize
+		{
+			dist = Uniform
+			min = Ratio(Tylo.sma, 2)
+			max = Ratio(Pol.sma, 1)
+		}
+
+ 		eccentricity
+		{
+			dist = Uniform
+			avg = 0.2
+			stddev = 0.5
+		}
+
+ 		inclination
+		{
+			dist = Uniform
+			min = 0
+			max = 180
+		}
+
+ 		ascNode
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		periapsis
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		orbitPhase
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		asteroidTypes
+		{
+			key = 0.75 PotatoRoid
+			key = 0.20 CaAsteroidCarbon
+			key = 0.05 CaAsteroidMetal
+		}
+	}
+
+ 	ASTEROIDGROUP
+	{
+		name = sarnusOuter
+		title = #autoLOC_CustomAsteroids_OPM_GroupOuterObj
+
+ 		centralBody = Sarnus
+
+ 		spawnRate = 0.10
+
+ 		orbitSize
+		{
+			dist = Uniform
+			min = Ratio(Slate.rad, 2)
+			max = Ratio(Tekto.rad, 1)
+		}
+
+ 		eccentricity
+		{
+			dist = Uniform
+			avg = 0.2
+			stddev = 0.5
+		}
+
+ 		inclination
+		{
+			dist = Uniform
+			min = 0
+			max = 180
+		}
+
+ 		ascNode
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		periapsis
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		orbitPhase
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		asteroidTypes
+		{
+			key = 0.75 PotatoRoid
+			key = 0.20 CaAsteroidCarbon
+			key = 0.05 CaAsteroidMetal
+		}
+	}
+
+ 	ASTEROIDGROUP
+	{
+		name = urlumOuter
+		title = #autoLOC_CustomAsteroids_OPM_GroupOuterObj
+
+ 		centralBody = Urlum
+
+ 		spawnRate = 0.10
+
+ 		orbitSize
+		{
+			dist = Uniform
+			min = Ratio(Priax.sma, 2)
+			max = Ratio(Wal.sma, 1)
+		}
+
+ 		eccentricity
+		{
+			dist = Uniform
+			avg = 0.2
+			stddev = 0.5
+		}
+
+ 		inclination
+		{
+			dist = Uniform
+			min = 0
+			max = 180
+		}
+
+ 		ascNode
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		periapsis
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		orbitPhase
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		asteroidTypes
+		{
+			key = 0.10 CaAsteroidCarbon
+			key = 0.90 CaAsteroidIcy
+		}
+	}
+
+ 	ASTEROIDGROUP
+	{
+		name = neidonOuter
+		title = #autoLOC_CustomAsteroids_OPM_GroupOuterObj
+
+ 		centralBody = Neidon
+
+ 		spawnRate = 0.15
+
+ 		orbitSize
+		{
+			dist = Uniform
+			min = Ratio(Thatmo.sma, 2)
+			max = Ratio(Nissee.sma, 1)
+		}
+
+ 		eccentricity
+		{
+			dist = Uniform
+			avg = 0.2
+			stddev = 0.5
+		}
+
+ 		inclination
+		{
+			dist = Uniform
+			min = 0
+			max = 180
+		}
+
+ 		ascNode
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		periapsis
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+
+ 		orbitPhase
+		{
+			dist = Uniform
+			min = 0
+			max = 360
+		}
+		
+ 		asteroidTypes
 		{
 			key = 0.10 CaAsteroidCarbon
 			key = 0.90 CaAsteroidIcy
 		}
 	}
 }
-  
+
 Localization
 {
 	en-us

--- a/config/OPM-Reconfig.cfg
+++ b/config/OPM-Reconfig.cfg
@@ -1,6 +1,6 @@
 // Updated 2019/03/18 by Eridan/HSJasperism
 // Tested with OPM 2.2.2 & CA 1.6
-// OPM older than 2.2.2 of OPM will include dated configs for CA or Kopernicus Asteroids
+// OPM older than 2.2.2 will include dated configs for CA or Kopernicus Asteroids
 // CA older than 1.3 will fail to recognize spawn conditions
 
 // Removes the Asteroid configs for Kopernicus

--- a/config/OPM-Reconfig.cfg
+++ b/config/OPM-Reconfig.cfg
@@ -1,7 +1,7 @@
 // Updated 2019/03/18 by Eridan/HSJasperism
 // Tested with OPM 2.2.2 & CA 1.6
 // OPM older than 2.2.2 will include dated configs for CA or Kopernicus Asteroids
-// CA older than 1.3 will fail to recognize spawn conditions
+// CA older than 1.3 will fail to recognize spawn conditions; older than 1.6 may have issues will localization strings
 
 // Removes the Asteroid configs for Kopernicus
 // Kopernicus will still load its ScenarioModule named DiscoverableObjects after killing stock ScenarioDiscoverableObjects
@@ -376,9 +376,9 @@ Localization
 	en-us
 	{
 		// Minor satellites
-    	#autoLOC_CustomAsteroids_OPM_GroupInnerObj = Minor Sat.
+    		#autoLOC_CustomAsteroids_OPM_GroupInnerObj = Minor Sat.
 		// Captured Objects
-    	#autoLOC_CustomAsteroids_OPM_GroupOuterObj = Captured Ast.
+    		#autoLOC_CustomAsteroids_OPM_GroupOuterObj = Captured Ast.
 	}
 }
 


### PR DESCRIPTION
OPM's Custom Asteroid support was removed in favor of Kopernicus, but the Kopernicus asteroid scenario module has terrible RNG and performs miserably with multiple asteroid group configs.

The new config turns off the Kopernicus configs and replaces them with CA.